### PR TITLE
Fix for new Cordova 7 behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nativesettingsopener",
-  "version": "1.2",
+  "version": "1.3.0",
   "description": "Native settings opener for Cordova 3.0",
   "cordova": {
     "id": "com.phonegap.plugins.nativesettingsopener",


### PR DESCRIPTION
This fix is necessary to allow new Cordova 7 to install this plugin with the "fetch" flag set to true (new default behaviour). Otherwise th einstallation will trow a "Invalid Version: 1.2" error.